### PR TITLE
Fix GCP credentials and update production env config

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,3 @@
-REACT_APP_DOC_API_URL=https://docai-backend-820551327432.northamerica-northeast2.run.app/extract
-# Optional: if hosting frontend separate from backend, set REACT_APP_API_URL to backend URL
-# REACT_APP_API_URL=https://your-backend-xyz.run.app
+REACT_APP_API_URL=
+REACT_APP_DOC_API_URL=
+REACT_APP_I18N_DEBUG=false


### PR DESCRIPTION
## Purpose

Based on the conversation history, the team was working on frontend deployment steps and encountered issues with GCP credentials when deploying to Cloud Run. The logs showed "Skipping BigQuery initialization: missing GCP credentials" errors, and there were discussions about proper environment variable configuration for Cloud Run deployment.

## Code changes

**Backend (server.js):**
- Removed explicit `projectId` configuration from BigQuery and Storage clients to use Application Default Credentials (ADC)
- Added `getProjectIdSafe()` function to dynamically resolve project ID from ADC or fallback to environment variable
- Removed conditional BigQuery initialization - now always initializes to let ADC provide credentials on Cloud Run
- Updated BigQuery queries to use dynamically resolved project ID instead of hardcoded `bigquery.projectId`

**Frontend (.env.production):**
- Cleared `REACT_APP_API_URL` and `REACT_APP_DOC_API_URL` values for proper configuration
- Added `REACT_APP_I18N_DEBUG=false` for production environment
- Removed commented backend URL references

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c13e3a336d74391a3731b7299b69800/vibe-haven)

👀 [Preview Link](https://1c13e3a336d74391a3731b7299b69800-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c13e3a336d74391a3731b7299b69800</projectId>-->
<!--<branchName>vibe-haven</branchName>-->