### PR TITLE
Fix ESLint errors: remove unused imports and dependencies

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { CssBaseline, Container } from '@mui/material';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { I18nextProvider, useTranslation } from 'react-i18next';
+import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 import Survey from './components/Survey';
 import ThankYou from './components/ThankYou';

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -6,7 +6,7 @@ import {
 } from '@mui/material';
 
 function Header() {
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
 
   const handleLanguageChange = (event) => {
     i18n.changeLanguage(event.target.value);

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Box, Card, CardContent, Stepper, Step, StepLabel,
   Button, TextField, Radio, RadioGroup, FormControlLabel,
   FormControl, FormLabel, Select, MenuItem, Checkbox,
-  FormGroup, Typography, LinearProgress, Alert,
+  FormGroup, Typography, LinearProgress,
   Dialog, DialogTitle, DialogContent, DialogActions
 } from '@mui/material';
 import { CloudUpload, NavigateNext, NavigateBefore } from '@mui/icons-material';
@@ -64,18 +64,18 @@ function Survey({ onComplete }) {
 
   useEffect(() => {
     loadSurveyDefinition();
-  }, [i18n.language]);
+  }, [loadSurveyDefinition]);
 
 
 
-  const loadSurveyDefinition = async () => {
+  const loadSurveyDefinition = useCallback(async () => {
     try {
       const response = await axios.get(`${API_URL}/api/survey/${i18n.language}`);
       setSurveyDefinition(response.data);
     } catch (error) {
       toast.error(t('error_loading_survey'));
     }
-  };
+  }, [i18n.language, t]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {


### PR DESCRIPTION
## Purpose

The user encountered a build failure during Docker image creation due to ESLint errors being treated as build-breaking issues in the CI environment. The build failed with multiple linting violations including unused imports and missing React Hook dependencies, preventing successful deployment.

## Code changes

- **App.js**: Removed unused `useEffect` and `useTranslation` imports
- **Header.js**: Removed unused `t` variable from `useTranslation` destructuring
- **Survey.js**: 
  - Removed unused `Alert` import
  - Added `useCallback` import and wrapped `loadSurveyDefinition` function
  - Fixed React Hook dependency array to include `loadSurveyDefinition` instead of `i18n.language`
  - Added proper dependencies (`i18n.language`, `t`) to the `useCallback` hook

These changes resolve all ESLint violations that were causing the CI build to fail while maintaining the same functionality.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c13e3a336d74391a3731b7299b69800/quantum-world)

👀 [Preview Link](https://1c13e3a336d74391a3731b7299b69800-quantum-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c13e3a336d74391a3731b7299b69800</projectId>-->
<!--<branchName>quantum-world</branchName>-->