### PR TITLE
Add cancer type question to CONNECT questionnaire

### DIFF
--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -62,12 +62,7 @@ function Survey({ onComplete }) {
   // Total steps calculation
   const totalSteps = staticSteps.length + surveyDefinition.length + 1; // +1 for review
 
-  useEffect(() => {
-    loadSurveyDefinition();
-  }, [loadSurveyDefinition]);
-
-
-
+  // Define before useEffect to satisfy eslint no-use-before-define
   const loadSurveyDefinition = useCallback(async () => {
     try {
       const response = await axios.get(`${API_URL}/api/survey/${i18n.language}`);
@@ -76,6 +71,10 @@ function Survey({ onComplete }) {
       toast.error(t('error_loading_survey'));
     }
   }, [i18n.language, t]);
+
+  useEffect(() => {
+    loadSurveyDefinition();
+  }, [loadSurveyDefinition]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -572,7 +572,7 @@ function Survey({ onComplete }) {
     }
   };
 
-  const renderDynamicQuestion = (question) => {
+  function renderDynamicQuestion(question) {
     const value = formData[question.id] || '';
     const error = errors[question.id];
     
@@ -667,7 +667,7 @@ function Survey({ onComplete }) {
     }
   };
 
-  const renderReview = () => {
+  function renderReview() {
     return (
       <Box>
         <Typography variant="h5" gutterBottom>{t('review_title')}</Typography>

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -31,6 +31,7 @@ function Survey({ onComplete }) {
     province: '',
     country: '',
     stage: '',
+    cancerType: '',
     stageConfirm: ''
   });
   const [extractedData, setExtractedData] = useState({});
@@ -56,6 +57,7 @@ function Survey({ onComplete }) {
     t('privacy_title'),
     t('report_title'),
     t('analysis_title'),
+    t('cancer_type_step'),
     t('stage_title')
   ];
 
@@ -204,7 +206,10 @@ function Survey({ onComplete }) {
       case 4: // Stage selection
         if (!formData.stage) newErrors.stage = t('required_field');
         break;
-      case 5: // Stage confirmation
+      case 5: // Cancer type
+        if (!formData.cancerType) newErrors.cancerType = t('required_field');
+        break;
+      case 6: // Stage confirmation
         if (!formData.stageConfirm) newErrors.stageConfirm = t('required_field');
         break;
       default:
@@ -236,7 +241,7 @@ function Survey({ onComplete }) {
       setExitDialog(true);
       return;
     }
-    if (activeStep === 5 && formData.stageConfirm === 'no') {
+    if (activeStep === 6 && formData.stageConfirm === 'no') {
       setActiveStep(4); // Go back to stage selection
       return;
     }
@@ -530,19 +535,38 @@ function Survey({ onComplete }) {
           </Box>
         );
         
-      case 5: // Stage confirmation
+      case 5: // Cancer type
+        return (
+          <Box>
+            <Typography variant="h5" gutterBottom>{t('cancer_type_title')}</Typography>
+            <FormControl component="fieldset" error={!!errors.cancerType}>
+              <FormLabel component="legend">{`${t('cancer_type_question')} *`}</FormLabel>
+              <RadioGroup
+                value={formData.cancerType}
+                onChange={(e) => setFormData({ ...formData, cancerType: e.target.value })}
+              >
+                <FormControlLabel value={t('cancer_type_ductal')} control={<Radio />} label={t('cancer_type_ductal')} />
+                <FormControlLabel value={t('cancer_type_lobular')} control={<Radio />} label={t('cancer_type_lobular')} />
+                <FormControlLabel value={t('cancer_type_sarcoma')} control={<Radio />} label={t('cancer_type_sarcoma')} />
+                <FormControlLabel value={t('cancer_type_inflammatory')} control={<Radio />} label={t('cancer_type_inflammatory')} />
+                <FormControlLabel value={t('cancer_type_unknown')} control={<Radio />} label={t('cancer_type_unknown')} />
+              </RadioGroup>
+            </FormControl>
+          </Box>
+        );
+      case 6: // Stage confirmation
         return (
           <Box>
             <Typography variant="h5" gutterBottom>{t('stage_title')}</Typography>
-            
+
             <Box sx={{ bgcolor: '#f8d7e4', p: 2, borderLeft: '4px solid #e5317a', mb: 3, textAlign: 'center' }}>
               <Typography variant="h6">
                 {t('stage_selected_text')} <strong>{formData.stage}</strong>
               </Typography>
             </Box>
-            
+
             <Typography paragraph dangerouslySetInnerHTML={{ __html: t('stage_text') }} />
-            
+
             <FormControl component="fieldset" error={!!errors.stageConfirm}>
               <FormLabel component="legend">{t('stage_confirm_label')} *</FormLabel>
               <RadioGroup
@@ -685,7 +709,8 @@ function Survey({ onComplete }) {
           <Typography><strong>{t('age_label')}:</strong> {formData.age}</Typography>
           <Typography><strong>{t('province_label')}:</strong> {formData.province}</Typography>
           <Typography><strong>{t('country_label')}:</strong> {formData.country}</Typography>
-          
+          <Typography><strong>{t('cancer_type_title')}:</strong> {formData.cancerType || t('not_specified')}</Typography>
+
           {surveyDefinition.map(q => {
             const value = formData[q.id];
             if (!value) return null;

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -95,7 +95,17 @@ const resources = {
       stage_confirm_label: "Is this correct?",
       proceed: "proceed",
       let_me_change: "let me change",
-      
+
+      // Cancer type
+      cancer_type_step: "Cancer Type",
+      cancer_type_title: "Cancer Type",
+      cancer_type_question: "What cancer type was your breast cancer?",
+      cancer_type_ductal: "Ductal carcinoma",
+      cancer_type_lobular: "Lobular carcinoma",
+      cancer_type_sarcoma: "Sarcoma",
+      cancer_type_inflammatory: "Inflammatory",
+      cancer_type_unknown: "Don’t know",
+
       // Review
       review_title: "Review & Submit",
       your_responses: "Your Responses",
@@ -218,7 +228,17 @@ const resources = {
       stage_confirm_label: "Est-ce correct?",
       proceed: "procéder",
       let_me_change: "laissez-moi changer",
-      
+
+      // Cancer type
+      cancer_type_step: "Type de cancer",
+      cancer_type_title: "Type de cancer",
+      cancer_type_question: "Quel type de cancer était votre cancer du sein?",
+      cancer_type_ductal: "Carcinome canalaire",
+      cancer_type_lobular: "Carcinome lobulaire",
+      cancer_type_sarcoma: "Sarcome",
+      cancer_type_inflammatory: "Inflammatoire",
+      cancer_type_unknown: "Je ne sais pas",
+
       // Review
       review_title: "Vérifier et soumettre",
       your_responses: "Vos réponses",


### PR DESCRIPTION
## Purpose
Add a mandatory cancer type question to the CONNECT questionnaire following the breast cancer stage question. This enhancement allows users to specify their specific breast cancer type (ductal carcinoma, lobular carcinoma, sarcoma, inflammatory, or don't know) as requested for improved data collection.

## Code changes
- Added new `cancerType` field to form state and validation
- Inserted cancer type step (step 5) between stage selection and stage confirmation
- Updated step numbering: stage confirmation moved from step 5 to step 6
- Added cancer type question UI with radio button options
- Included cancer type data in review section
- Added English and French translations for all cancer type labels and options
- Fixed ESLint warning by moving function declaration before useEffect

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c13e3a336d74391a3731b7299b69800/swoosh-verse)

👀 [Preview Link](https://1c13e3a336d74391a3731b7299b69800-swoosh-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c13e3a336d74391a3731b7299b69800</projectId>-->
<!--<branchName>swoosh-verse</branchName>-->