### PR TITLE
Fix multi-report data extraction and field mapping

### DIFF
--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -165,13 +165,35 @@ function Survey({ onComplete }) {
       const payload = response.data?.data || response.data || {};
       setExtractedData(payload);
 
-      // Prefill form with extracted data
+      // Normalize stage to the base option label for the select (e.g., "Stage II TNBC" -> "Stage II")
+      const normalizedStage = (() => {
+        const s = String(payload.stage || '').trim();
+        if (/^Stage\s+(0|I{1,3}|IV)\b/i.test(s)) {
+          const m = s.match(/^(Stage\s+(?:0|I{1,3}|IV))/i);
+          return m ? m[1].replace(/\s+/g, ' ') : '';
+        }
+        if (/DCIS/i.test(s)) return 'DCIS / Stage 0';
+        return s;
+      })();
+
+      // Prefill form with extracted data, mapping to dynamic fields when possible
       setFormData(prev => ({
         ...prev,
         age: payload.age || prev.age,
         province: payload.province || prev.province,
         country: payload.country || prev.country,
-        stage: payload.stage || prev.stage
+        stage: normalizedStage || prev.stage,
+        ERPR: payload.ERPR || prev.ERPR,
+        HER2: payload.HER2 || prev.HER2,
+        luminal: payload.luminal || prev.luminal,
+        BRCA: payload.BRCA || prev.BRCA,
+        PIK3CA: payload.PIK3CA || prev.PIK3CA,
+        ESR1: payload.ESR1 || prev.ESR1,
+        PDL1: payload.PDL1 || prev.PDL1,
+        MSI: payload.MSI || prev.MSI,
+        Ki67: payload.Ki67 || prev.Ki67,
+        PTEN: payload.PTEN || prev.PTEN,
+        AKT1: payload.AKT1 || prev.AKT1
       }));
 
       toast.success(t('upload_successful'));


### PR DESCRIPTION
## Purpose

The user reported issues with medical report data extraction where:
- Multiple reports of the same type weren't prioritizing the most recent data
- ER/PR, HER2, and other biomarker fields weren't being properly populated in the UI
- Province extraction was incorrectly showing "NU" instead of proper values
- Stage determination needed improvement for TNBC cases
- BRCA reports needed to be handled separately and intelligently merged with other report types

## Code changes

**Backend improvements:**
- Added `parseReportDate()` function to extract report dates from medical documents
- Implemented field-level timestamp tracking to prefer most recent values when merging multiple uploads
- Enhanced province extraction patterns with better regex matching and word boundaries
- Added "PgR" as an alternative pattern for progesterone receptor detection
- Modified data merging logic to compare timestamps per field rather than overwriting entire datasets

**Frontend enhancements:**
- Added stage normalization to map extracted stages (e.g., "Stage II TNBC") to proper select options
- Extended form prefilling to include all biomarker fields (ERPR, HER2, luminal, BRCA, PIK3CA, ESR1, PDL1, MSI, Ki67, PTEN, AKT1)
- Improved stage mapping logic to handle DCIS and other stage variations

These changes ensure that when users upload multiple reports, the system intelligently extracts and merges data from the most recent reports while properly populating all relevant form fields.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c13e3a336d74391a3731b7299b69800/nova-haven)

👀 [Preview Link](https://1c13e3a336d74391a3731b7299b69800-nova-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c13e3a336d74391a3731b7299b69800</projectId>-->
<!--<branchName>nova-haven</branchName>-->