### PR TITLE
Fix: Update Lobular Carcinoma PDF Mappings

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -27,11 +27,11 @@ const PDF_MAPPING = {
 
 // Lobular carcinoma PDF mapping - direct URLs from GCS
 const LOBULAR_PDF_MAPPING = {
-  'LCIS': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_CARCINOMA_IN-SITU_(LCIS)_2.pdf',
-  'Stage 1 Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/STAGE_1_LOBULAR_BREAST_CANCER_2.pdf',
-  'Stage II Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LCIC_stage_II_2.pdf',
-  'Stage III Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LCIC_stage_III_2.pdf',
-  'Stage IV Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/Stage_IV_ILC_Breast_Cancer_2.pdf'
+  'Stage 0 Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_Stage0.pdf',
+  'Stage I Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageI.pdf',
+  'Stage II Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageII.pdf',
+  'Stage III Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageIII.pdf',
+  'Stage IV Lobular': 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageIV.pdf'
 };
 
 // Biomarker-based PDF routing for non-Lobular cancers

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -651,12 +651,12 @@ function Survey({ onComplete }) {
         return (
           <Box>
             <Typography variant="h5" gutterBottom>{t('analysis_title')}</Typography>
-            
+
             <FormControl fullWidth error={!!errors.stage}>
               <FormLabel>{t('stage_select_label')} *</FormLabel>
               <Select
                 value={formData.stage}
-                onChange={(e) => setFormData({...formData, stage: e.target.value})}
+                onChange={(e) => { setFormData({...formData, stage: e.target.value}); setFieldOrigins(prev => ({ ...prev, stage: 'user' })); }}
                 displayEmpty
               >
                 <MenuItem value="">— {t('select_stage')} —</MenuItem>

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -117,6 +117,18 @@ function Survey({ onComplete }) {
     loadSurveyDefinition();
   }, [loadSurveyDefinition]);
 
+  // Update Lobular PDF when stage changes (if Lobular is selected)
+  useEffect(() => {
+    if (formData.cancerType === t('cancer_type_lobular') && formData.stage) {
+      const pdfMapping = LOBULAR_PDF_MAP[formData.stage];
+      if (pdfMapping) {
+        setSelectedPdfName(pdfMapping.name);
+      } else {
+        setSelectedPdfName('');
+      }
+    }
+  }, [formData.stage, formData.cancerType, t]);
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
       'application/pdf': ['.pdf'],

--- a/frontend/src/components/Survey.js
+++ b/frontend/src/components/Survey.js
@@ -19,24 +19,24 @@ const DOC_API_URL = process.env.REACT_APP_DOC_API_URL || '';
 // Lobular carcinoma PDF mapping by stage
 const LOBULAR_PDF_MAP = {
   'DCIS / Stage 0': {
-    name: 'LCIS',
-    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_CARCINOMA_IN-SITU_(LCIS)_2.pdf'
+    name: 'Stage 0 Lobular',
+    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_Stage0.pdf'
   },
   'Stage I': {
-    name: 'Stage 1 Lobular',
-    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/STAGE_1_LOBULAR_BREAST_CANCER_2.pdf'
+    name: 'Stage I Lobular',
+    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageI.pdf'
   },
   'Stage II': {
     name: 'Stage II Lobular',
-    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LCIC_stage_II_2.pdf'
+    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageII.pdf'
   },
   'Stage III': {
     name: 'Stage III Lobular',
-    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LCIC_stage_III_2.pdf'
+    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageIII.pdf'
   },
   'Stage IV': {
     name: 'Stage IV Lobular',
-    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/Stage_IV_ILC_Breast_Cancer_2.pdf'
+    url: 'https://storage.googleapis.com/bcc-connect-pdfs/con/LOBULAR_StageIV.pdf'
   }
 };
 


### PR DESCRIPTION
### Purpose

The user wants to correct the PDF documents assigned to patients who select "Lobular Carcinoma". The correct PDF should be determined by the cancer stage, overriding other criteria. This change ensures the right PDF is selected based on the stage for this specific cancer type.

### Code changes

- Updated the `LOBULAR_PDF_MAPPING` in `backend/utils.js` and `LOBULAR_PDF_MAP` in `frontend/src/components/Survey.js` with the correct URLs and stage names for Lobular Carcinoma.
- Renamed stage keys for consistency (e.g., `LCIS` is now `Stage 0 Lobular`).
- Added a `useEffect` hook to the `Survey.js` component. This dynamically updates the selected PDF when the stage Veränderungen for a patient with Lobular Carcinoma.
- Modified the `onChange` handler for the stage `Select` component to track that the field was changed by the user.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0b9447a0f2e54c0ca4e192c843c39031/mystic-oasis)

👀 [Preview Link](https://0b9447a0f2e54c0ca4e192c843c39031-mystic-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b9447a0f2e54c0ca4e192c843c39031</projectId>-->
<!--<branchName>mystic-oasis</branchName>-->